### PR TITLE
Fix homepage button text in light mode

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -103,7 +103,7 @@ const { lightbox } = Astro.props
           ].map((social) => (
             <a
               href={social.href}
-              class="flex items-center justify-center gap-1 rounded-md border-2 border-accent-7 bg-accent-1 px-3 py-1 text-sm text-white shadow-md shadow-accent-8 transition-all hover:scale-105 hover:bg-accent-3 hover:shadow-accent-3 dark:border-accent-12 dark:hover:shadow-accent-12"
+              class="flex items-center justify-center gap-1 rounded-md border-2 border-accent-7 bg-accent-1 px-3 py-1 text-sm text-accent-12 shadow-md shadow-accent-8 transition-all hover:scale-105 hover:bg-accent-3 hover:shadow-accent-3 dark:border-accent-12 dark:text-white dark:hover:shadow-accent-12"
             >
               <Icon name={social.icon} />
               <span>{social.name}</span>


### PR DESCRIPTION
Social buttons on the home page had white text on a light background, making them invisible in light mode. Switched to accent-12 in light mode and kept white in dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated social link text colors for improved visual consistency across light and dark modes. Social links now display in accent color in light mode and white in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->